### PR TITLE
feat(sessions): refactor to separate commands instead of flags

### DIFF
--- a/bundles/sessions-workflow-bundle/.claude-plugin/plugin.json
+++ b/bundles/sessions-workflow-bundle/.claude-plugin/plugin.json
@@ -11,6 +11,7 @@
   ],
   "commands": [
     "./commands/session-start.md",
+    "./commands/session-start-teach.md",
     "./commands/session-end.md"
   ]
 }

--- a/bundles/sessions-workflow-bundle/README.md
+++ b/bundles/sessions-workflow-bundle/README.md
@@ -4,9 +4,10 @@ Token-efficient session management for Claude Code - load project context at the
 
 ## 🎯 What It Does
 
-This bundle provides two essential commands for managing focused development sessions:
+This bundle provides three essential commands for managing focused development sessions:
 
-- **`/session-start`** - Load project context (CLAUDE.md, README, previous sessions, git state) in ~1500-2000 tokens
+- **`/session-start`** - Load project context with brief summaries (standard mode) in ~3200-3500 tokens
+- **`/session-start-teach`** - Load context with educational explanations (teacher mode) in ~4200-4500 tokens
 - **`/session-end`** - Create session summary, commit changes, and detect commit style in ~2000-2500 tokens
 
 Plus a flexible **session-manager** skill for non-command workflows.
@@ -22,6 +23,7 @@ Plus a flexible **session-manager** skill for non-command workflows.
 
 ### Basic Workflow
 
+**Standard Mode (brief, efficient):**
 ```bash
 # Start your session - loads all context automatically
 /session-start
@@ -31,6 +33,32 @@ Plus a flexible **session-manager** skill for non-command workflows.
 # End your session - creates summary and commits
 /session-end
 ```
+
+**Teacher Mode (educational, verbose):**
+```bash
+# Start with educational context - perfect for learning
+/session-start-teach
+
+# ... work on your code with deeper understanding ...
+
+# End your session - creates summary and commits
+/session-end
+```
+
+### 🎓 Two Session Start Modes
+
+**Standard Mode** (`/session-start`):
+- Brief, efficient context loading
+- ~300 word summaries
+- Focus on actionable information
+- **Best for:** Daily work, experienced developers, token efficiency
+
+**Teacher Mode** (`/session-start-teach`):
+- Educational explanations and learning context
+- ~500-700 word responses with insights
+- Step-by-step narration of what's happening
+- Discussion questions and alternative approaches
+- **Best for:** Learning new codebases, onboarding, understanding patterns
 
 ## 📚 Features
 
@@ -128,19 +156,30 @@ For non-command workflows:
 
 ### Pattern 1: Full Automation (Recommended)
 
+**Standard Mode:**
 ```bash
 /session-start          # Load context
 # ... 1-2 hours of work ...
 /session-end            # Summary + commit
 ```
 
+**Teacher Mode:**
+```bash
+/session-start-teach    # Load context with education
+# ... 1-2 hours of work ...
+/session-end            # Summary + commit
+```
+
 **Advantages:**
 - Fully automatic
-- Optimal token usage (~3500-4500 tokens total)
+- Optimal token usage (~4500-5000 standard, ~5500-6000 teacher)
 - Ensures commits happen
 - Consistent documentation
+- Teacher mode provides learning context
 
-**Best for:** Regular development sessions, focused work, team projects
+**Best for:**
+- Standard: Regular development sessions, focused work, team projects
+- Teacher: Learning new codebases, onboarding, understanding patterns
 
 ### Pattern 2: Interactive Workflow
 
@@ -160,9 +199,19 @@ For non-command workflows:
 
 ### Pattern 3: Hybrid (Complex Work)
 
+**Standard Mode:**
 ```bash
 /session-start                    # Load context
 # ... work on complex feature ...
+"Take a checkpoint - create a mid-session summary"
+# ... continue working ...
+/session-end                      # Final commit
+```
+
+**Teacher Mode (for learning):**
+```bash
+/session-start-teach              # Load educational context
+# ... work on complex feature with explanations ...
 "Take a checkpoint - create a mid-session summary"
 # ... continue working ...
 /session-end                      # Final commit
@@ -172,8 +221,9 @@ For non-command workflows:
 - Automatic structure
 - Manual checkpoints for complex work
 - Document progress without committing
+- Teacher mode helps understand decisions
 
-**Best for:** Long sessions, multi-part features, refactoring
+**Best for:** Long sessions, multi-part features, refactoring, learning complex patterns
 
 ## 📊 Token Budget
 
@@ -181,9 +231,11 @@ This bundle is designed for minimal token usage:
 
 | Operation | Tokens | Details |
 |-----------|--------|---------|
-| `/session-start` | 1500-2000 | Load context + analysis |
+| `/session-start` | 3200-3500 | Standard mode: brief context |
+| `/session-start-teach` | 4200-4500 | Teacher mode: educational context |
 | `/session-end` | 2000-2500 | Create summary + commit |
-| **Total per session** | **3500-4500** | ~80% savings vs naive approach |
+| **Total per session (standard)** | **4500-5000** | Efficient for daily work |
+| **Total per session (teacher)** | **5500-6000** | Educational, great for learning |
 
 ### Optimization Techniques
 
@@ -217,7 +269,8 @@ This bundle is designed for minimal token usage:
 ```
 sessions-workflow-bundle/
 ├── commands/
-│   ├── session-start.md        # Load project context
+│   ├── session-start.md        # Load project context (standard mode)
+│   ├── session-start-teach.md  # Load context with education (teacher mode)
 │   └── session-end.md          # Create summary and commit
 ├── skills/
 │   └── session-manager/        # Flexible session workflows
@@ -323,14 +376,16 @@ You can customize this by editing the `/session-end` command.
 
 ### Adjusting Token Budget
 
-By default, the commands target ~3500-4500 tokens per full session.
+By default, the commands target ~4500-5000 tokens per full session (standard) or ~5500-6000 (teacher).
 
 To **reduce tokens further**:
-- Edit `/session-start` to skip reading CLAUDE.md or README.md
+- Use `/session-start` (standard mode) instead of `/session-start-teach`
+- Edit commands to skip reading CLAUDE.md or README.md
 - Use `/session-end` without creating detailed summaries
 - Reduce git history analysis (currently checks 5 commits)
 
 To **load more context**:
+- Use `/session-start-teach` for educational content
 - Increase file size limits (currently first N lines)
 - Load more documentation files
 - Include more git history

--- a/bundles/sessions-workflow-bundle/commands/session-start-teach.md
+++ b/bundles/sessions-workflow-bundle/commands/session-start-teach.md
@@ -1,0 +1,135 @@
+---
+name: session-start-teach
+description: Initialize a session in teacher mode with educational explanations, learning context, and interactive guidance. Perfect for learning sessions and understanding project patterns.
+allowed-tools: Bash(pwd), Bash(git branch), Bash(git status), Bash(git log), Bash(find), Read, Glob
+model: haiku
+---
+
+# /session-start-teach
+
+Initialize a new Claude Code session with full context loading in **Teacher Mode** - providing educational explanations, learning context, and interactive guidance.
+
+---
+
+## Context Loading
+
+Load this context to understand the project:
+
+### Project Information
+- Working directory: !`pwd`
+- Current branch: !`git branch --show-current`
+- Git status: !`git status --short`
+
+### Recent Work
+- Last 5 commits: !`git log --oneline -5`
+- Available session files: !`find docs/sessions -name "*.md" -type f 2>/dev/null | tail -10`
+
+### Project Guidelines
+See @CLAUDE.md for complete project guidance, conventions, and instructions.
+
+### Available Documentation
+Documentation files: !`find docs -maxdepth 3 -type f \( -name "README.md" -o -name "INDEX.md" -o -name "*.md" \) 2>/dev/null | grep -E "(README|INDEX|technical|technique|documentation)" | head -20`
+
+**Note**: Documentation is listed but not loaded to conserve tokens. Suggest specific files if relevant to the user's work.
+
+---
+
+## 🎓 Teacher Mode Instructions
+
+### Your Task
+
+1. **Explain your process** - Narrate each step as you load context and explain why it matters
+2. **Provide learning context** - Explain patterns, conventions, and best practices
+3. **Share insights** - Connect observations to industry standards and project decisions
+4. **Ask follow-up questions** - Encourage deeper understanding and critical thinking
+5. **Present alternatives** - Show multiple approaches with trade-offs explained
+6. **Invite exploration** - Suggest areas to learn more about
+
+### Teacher Mode Behavior
+
+Enhance your response with educational content:
+
+1. **Explain every action**
+   - Narrate what you're doing: "I'm reading CLAUDE.md to understand project conventions..."
+   - Explain why: "Checking git status helps identify uncommitted work that might affect today's tasks"
+   - Show your reasoning: "Based on the previous session, I notice you were working on X, so I'll focus on related patterns"
+
+2. **Provide learning context**
+   - Add educational notes: "This project uses conventional commits, which help generate changelogs automatically"
+   - Explain best practices: "Session summaries create project memory, making it easier to resume work after breaks"
+   - Share pattern insights: "I notice this codebase follows [specific pattern], which is useful because..."
+
+3. **Ask follow-up questions**
+   - After summarizing previous work: "Do you understand why the previous session chose approach X over Y?"
+   - About current state: "Would you like me to explain any unfamiliar patterns in the codebase?"
+   - For next steps: "Would you prefer to continue the previous work or start something new? Let me explain the trade-offs..."
+
+4. **Show alternative approaches**
+   - Present multiple paths: "We could approach today's work by: A) continuing feature X, B) addressing technical debt, or C) adding tests"
+   - Explain trade-offs: "Approach A is faster but approach B reduces future maintenance burden"
+   - Encourage critical thinking: "What factors are most important for your decision?"
+
+### Response Format
+
+Provide an expanded educational response:
+
+```
+📚 Session Context Loaded (Teacher Mode)
+
+🔍 Context Discovery Process:
+[Narrate what you did and why - explain each step taken to load context]
+
+✓ Current branch: [branch name]
+  → [Explain what this branch represents and why it matters]
+
+✓ Git status: [uncommitted changes summary]
+  → [Explain implications of uncommitted changes]
+
+✓ Documentation: [count] files found
+  → [Explain what documentation exists]
+  → [Offer to review specific docs if relevant]
+  → [Educational insight about documentation structure]
+
+✓ Project guidelines: [key constraints from CLAUDE.md]
+  → [Provide learning context about these patterns/conventions]
+  → [Explain why these guidelines exist]
+
+✓ Previous work: [summary from latest session file]
+  → [Explain the decisions made in previous session]
+  → [Highlight key patterns or techniques used]
+
+💡 Learning Points:
+- [Educational insight 1]
+- [Educational insight 2]
+- [Best practice observation]
+
+🤔 Discussion Questions:
+- [Follow-up question about previous work]
+- [Question about understanding project patterns]
+- [Question about user's preferences for today's work]
+
+🛤️ Possible Paths Forward:
+A) [Option 1] - [Trade-offs and reasoning]
+B) [Option 2] - [Trade-offs and reasoning]
+C) [Option 3] - [Trade-offs and reasoning]
+
+What would you like to explore today?
+```
+
+### Guidelines
+- Responses can be 500-700 words (educational priority, not brevity)
+- Explain the "why" behind everything
+- Ask questions that encourage critical thinking
+- Present multiple approaches with trade-offs
+- Suggest documentation reviews when relevant to the work
+- Focus on helping the user understand project patterns and practices
+
+---
+
+## Notes
+
+- Missing files (CLAUDE.md, session history, docs/) should not block session start - handle gracefully
+- Always gracefully handle missing directories or files
+- Teacher mode responses will be longer (500-700 words) to include educational content
+- Prioritize learning and understanding over brevity
+- Focus on explaining patterns, conventions, and best practices

--- a/bundles/sessions-workflow-bundle/commands/session-start.md
+++ b/bundles/sessions-workflow-bundle/commands/session-start.md
@@ -1,41 +1,21 @@
 ---
 name: session-start
-description: Initialize and load session context including project information, CLAUDE.md memory, recent work, and git status. Use when starting a new session or needing full project context. Supports --teacher flag for educational mode.
+description: Initialize and load session context including project information, CLAUDE.md memory, recent work, and git status. Use when starting a new session or needing full project context. Provides brief, efficient summaries.
 allowed-tools: Bash(pwd), Bash(git branch), Bash(git status), Bash(git log), Bash(find), Read, Glob
 model: haiku
 ---
 
 # /session-start
 
-Initialize a new Claude Code session with full context loading.
+Initialize a new Claude Code session with full context loading. Provides brief, efficient summaries focused on actionable information.
 
-## Arguments
-
-- `--teacher` (optional): Enable teacher mode with educational explanations, learning context, and interactive guidance
+For educational mode with detailed explanations and learning context, use `/session-start-teach` instead.
 
 ---
 
-## ⚠️ MODE DETECTION - READ THIS FIRST
+## Context Loading
 
-**CRITICAL**: Check if the `--teacher` flag was provided when this command was invoked.
-
-### If `--teacher` flag IS PRESENT:
-→ **ACTIVATE TEACHER MODE** (skip to "🎓 TEACHER MODE INSTRUCTIONS" section below)
-→ Follow teacher mode instructions exclusively
-→ Do NOT follow standard mode instructions
-
-### If `--teacher` flag IS NOT PRESENT:
-→ **ACTIVATE STANDARD MODE** (skip to "📋 STANDARD MODE INSTRUCTIONS" section below)
-→ Follow standard mode instructions exclusively
-→ Do NOT follow teacher mode instructions
-
-**You MUST choose ONE mode. Do NOT blend instructions from both modes.**
-
----
-
-## Context Loading (Applies to ALL Modes)
-
-Load this context regardless of which mode is active:
+Load this context to understand the project:
 
 ### Project Information
 - Working directory: !`pwd`
@@ -56,9 +36,7 @@ Documentation files: !`find docs -maxdepth 3 -type f \( -name "README.md" -o -na
 
 ---
 
-## 📋 STANDARD MODE INSTRUCTIONS
-
-**Use this section ONLY if `--teacher` flag is NOT present.**
+## Instructions
 
 ### Your Task
 
@@ -94,105 +72,10 @@ What would you like to work on today?
 
 ---
 
-## 🎓 TEACHER MODE INSTRUCTIONS
-
-**Use this section ONLY if `--teacher` flag IS present.**
-
-### Your Task
-
-1. **Explain your process** - Narrate each step as you load context and explain why it matters
-2. **Provide learning context** - Explain patterns, conventions, and best practices
-3. **Share insights** - Connect observations to industry standards and project decisions
-4. **Ask follow-up questions** - Encourage deeper understanding and critical thinking
-5. **Present alternatives** - Show multiple approaches with trade-offs explained
-6. **Invite exploration** - Suggest areas to learn more about
-
-### Teacher Mode Behavior
-
-Enhance your response with educational content:
-
-1. **Explain every action**
-   - Narrate what you're doing: "I'm reading CLAUDE.md to understand project conventions..."
-   - Explain why: "Checking git status helps identify uncommitted work that might affect today's tasks"
-   - Show your reasoning: "Based on the previous session, I notice you were working on X, so I'll focus on related patterns"
-
-2. **Provide learning context**
-   - Add educational notes: "This project uses conventional commits, which help generate changelogs automatically"
-   - Explain best practices: "Session summaries create project memory, making it easier to resume work after breaks"
-   - Share pattern insights: "I notice this codebase follows [specific pattern], which is useful because..."
-
-3. **Ask follow-up questions**
-   - After summarizing previous work: "Do you understand why the previous session chose approach X over Y?"
-   - About current state: "Would you like me to explain any unfamiliar patterns in the codebase?"
-   - For next steps: "Would you prefer to continue the previous work or start something new? Let me explain the trade-offs..."
-
-4. **Show alternative approaches**
-   - Present multiple paths: "We could approach today's work by: A) continuing feature X, B) addressing technical debt, or C) adding tests"
-   - Explain trade-offs: "Approach A is faster but approach B reduces future maintenance burden"
-   - Encourage critical thinking: "What factors are most important for your decision?"
-
-### Response Format
-
-Provide an expanded educational response:
-
-```
-📚 Session Context Loaded (Teacher Mode)
-
-🔍 Context Discovery Process:
-[Narrate what you did and why - explain each step taken to load context]
-
-✓ Current branch: [branch name]
-  → [Explain what this branch represents and why it matters]
-
-✓ Git status: [uncommitted changes summary]
-  → [Explain implications of uncommitted changes]
-
-✓ Documentation: [count] files found
-  → [Explain what documentation exists]
-  → [Offer to review specific docs if relevant]
-  → [Educational insight about documentation structure]
-
-✓ Project guidelines: [key constraints from CLAUDE.md]
-  → [Provide learning context about these patterns/conventions]
-  → [Explain why these guidelines exist]
-
-✓ Previous work: [summary from latest session file]
-  → [Explain the decisions made in previous session]
-  → [Highlight key patterns or techniques used]
-
-💡 Learning Points:
-- [Educational insight 1]
-- [Educational insight 2]
-- [Best practice observation]
-
-🤔 Discussion Questions:
-- [Follow-up question about previous work]
-- [Question about understanding project patterns]
-- [Question about user's preferences for today's work]
-
-🛤️ Possible Paths Forward:
-A) [Option 1] - [Trade-offs and reasoning]
-B) [Option 2] - [Trade-offs and reasoning]
-C) [Option 3] - [Trade-offs and reasoning]
-
-What would you like to explore today?
-```
-
-### Guidelines
-- Responses can be 500-700 words (educational priority, not brevity)
-- Explain the "why" behind everything
-- Ask questions that encourage critical thinking
-- Present multiple approaches with trade-offs
-- Suggest documentation reviews when relevant to the work
-- Focus on helping the user understand project patterns and practices
-
----
-
 ## Notes
 
 - Missing files (CLAUDE.md, session history, docs/) should not block session start - handle gracefully
 - Always gracefully handle missing directories or files
-- Standard mode: Keep summary brief (~300 words max) to save tokens
-- Teacher mode: Responses will be longer (500-700 words) to include educational content
+- Keep summary brief (~300 words max) to save tokens
 - Focus on critical information that affects today's work
-- In teacher mode, prioritize learning and understanding over brevity
+- For educational mode with detailed explanations, use `/session-start-teach` instead

--- a/bundles/sessions-workflow-bundle/skills/session-manager/SKILL.md
+++ b/bundles/sessions-workflow-bundle/skills/session-manager/SKILL.md
@@ -154,17 +154,18 @@ The best part: You can use `/session-start` and `/session-end` for automatic wor
 
 ### Pattern 1: Slash Command Workflow (Recommended)
 
+**Standard Mode (brief, efficient):**
 ```bash
 /session-start          # Load context automatically
 # ... work for 1-2 hours ...
 /session-end            # Create summary and commit automatically
 ```
 
-**With Teacher Mode:**
+**Teacher Mode (educational, verbose):**
 ```bash
-/session-start --teacher    # Load context with educational explanations
+/session-start-teach    # Load context with educational explanations
 # ... work for 1-2 hours ...
-/session-end                # Create summary and commit automatically
+/session-end            # Create summary and commit automatically
 ```
 
 **Advantages:**
@@ -174,9 +175,9 @@ The best part: You can use `/session-start` and `/session-end` for automatic wor
 - Optimal token usage (standard mode)
 - Teacher mode helps learn patterns and best practices
 
-**Token cost** (with v2.0 doc scanning):
-- Standard: ~4500-5500 per session start (start + end combined ~5500-6500)
-- Teacher mode: ~5500-6500 per session start (includes educational content; start + end combined ~6500-7500)
+**Token cost** (with v3.0 separate commands):
+- Standard: ~3200-3500 per session start (start + end combined ~4500-5000)
+- Teacher mode: ~4200-4500 per session start (includes educational content; start + end combined ~5500-6000)
 
 ### Pattern 2: Skill-Based Workflow (Flexible)
 
@@ -249,13 +250,13 @@ Each session:
 
 ## Teacher Mode
 
-**Teacher Mode** is an educational enhancement for `/session-start` that transforms context loading into a learning experience.
+**Teacher Mode** is a separate command (`/session-start-teach`) that transforms context loading into a learning experience.
 
 ### What is Teacher Mode?
 
-Enable with: `/session-start --teacher`
+Use the command: `/session-start-teach`
 
-Instead of a brief context summary, you get:
+Instead of a brief context summary (from `/session-start`), you get:
 - **Step-by-step narration** of what Claude is doing and why
 - **Learning context** about patterns, conventions, and best practices
 - **Discussion questions** to deepen understanding
@@ -272,7 +273,7 @@ Use teacher mode when:
 
 ### Teacher Mode Behavior
 
-When teacher mode is enabled, `/session-start` will:
+When you use `/session-start-teach`, it will:
 
 1. **Explain every action taken**
    - "I'm reading CLAUDE.md to understand project conventions..."
@@ -293,27 +294,20 @@ When teacher mode is enabled, `/session-start` will:
    - Explain trade-offs between options
    - Encourage critical thinking about choices
 
-### Mode Detection
+### Command Separation
 
-Starting with `/session-start` version 2.0, the command includes explicit **MODE DETECTION** at the top:
+Starting with version 3.0, standard and teacher modes are now **separate commands**:
 
-```
-## ⚠️ MODE DETECTION - READ THIS FIRST
+- **`/session-start`** - Brief, efficient context loading (standard mode)
+- **`/session-start-teach`** - Educational context loading with explanations (teacher mode)
 
-**CRITICAL**: Check if the `--teacher` flag was provided when this command was invoked.
+**Why separate commands?**
+- **Reliability**: No conditional logic = no ambiguity
+- **Clarity**: Each command has one clear purpose
+- **Token efficiency**: Only loads relevant instructions (no unused sections)
+- **Maintainability**: Self-contained files are easier to modify
 
-### If `--teacher` flag IS PRESENT:
-→ **ACTIVATE TEACHER MODE**
-→ Follow teacher mode instructions exclusively
-
-### If `--teacher` flag IS NOT PRESENT:
-→ **ACTIVATE STANDARD MODE**
-→ Follow standard mode instructions exclusively
-
-**You MUST choose ONE mode. Do NOT blend instructions from both modes.**
-```
-
-This explicit routing makes it impossible for Claude to miss which mode is active.
+This eliminates the need for flag-based mode detection and prevents instruction blending.
 
 ### Documentation Scanning
 
@@ -332,7 +326,7 @@ The command now scans for and lists available documentation during session start
 
 ### Example Comparison
 
-**Standard Mode (without --teacher):**
+**Standard Mode (`/session-start`):**
 ```
 📚 Session Context Loaded
 
@@ -345,7 +339,7 @@ The command now scans for and lists available documentation during session start
 What would you like to work on today?
 ```
 
-**Teacher Mode (with --teacher):**
+**Teacher Mode (`/session-start-teach`):**
 ```
 📚 Session Context Loaded (Teacher Mode)
 
@@ -394,21 +388,25 @@ What would you like to explore today?
 
 ### Token Cost Consideration
 
-**After documentation scanning addition (v2.0)**:
+**With separate commands (v3.0)**:
 
-- **Standard mode**: ~4500 tokens for session start (up from 3700)
-  - Context loading: ~3200 tokens
+- **Standard mode** (`/session-start`): ~3200-3500 tokens
+  - Context loading: ~2500-2800 tokens
   - Documentation scanning: ~300-500 tokens
   - Response: ~400-800 tokens
 
-- **Teacher mode**: ~5500 tokens for session start (up from 4700)
-  - Context loading: ~4000 tokens
+- **Teacher mode** (`/session-start-teach`): ~4200-4500 tokens
+  - Context loading: ~2500-2800 tokens
   - Documentation scanning: ~300-500 tokens
   - Response: ~1000-1500 tokens
 
+**Token savings vs flag-based approach (v2.0)**:
+- Standard: **-1300 tokens** (each command only loads relevant instructions)
+- Teacher: **-1300 tokens** (no unused standard mode section)
+
 **Still well within budget** (target: <6000 tokens per session start)
 
-**Recommendation**: Use teacher mode selectively when learning is the priority. Once familiar with the codebase, switch back to standard mode for efficiency. Documentation is listed but not loaded, keeping token usage reasonable.
+**Recommendation**: Use teacher mode selectively when learning is the priority. Once familiar with the codebase, switch to standard mode for efficiency. Documentation is listed but not loaded, keeping token usage reasonable.
 
 ## Session Summary Format
 
@@ -586,25 +584,25 @@ For detailed information, see:
 ## Quick Tips
 
 1. **Use `/session-start` first** - Always load context before starting work
-2. **Enable teacher mode when learning** - Use `/session-start --teacher` for new codebases
+2. **Enable teacher mode when learning** - Use `/session-start-teach` for new codebases
 3. **Take checkpoint summaries** - For long sessions, document mid-session progress
 4. **Use `/session-end` at end** - Automatic summary creation and commit
 5. **Review summaries** - Check docs/sessions/ to understand project history
 6. **Reference previous sessions** - Build on what was learned before
-7. **Switch to standard mode when familiar** - Save tokens once you know the patterns
+7. **Switch to standard mode when familiar** - Use `/session-start` to save tokens once you know the patterns
 
 ## When to Use This Skill vs Slash Commands
 
 | Situation | Use | Reason |
 |-----------|-----|--------|
 | Starting a new session | `/session-start` | Automatic, optimal tokens |
-| Learning new codebase | `/session-start --teacher` | Educational context, explanations |
+| Learning new codebase | `/session-start-teach` | Educational context, explanations |
 | Ending session normally | `/session-end` | Automatic, creates commit |
 | Need to review context | This skill | "What did we work on?" |
 | Need to document mid-session | This skill | "Checkpoint summary..." |
 | Working in bursts | This skill | More flexible timing |
 | Want full automation | `/session-start` + `/session-end` | Fastest, most efficient |
-| Want to understand patterns | `/session-start --teacher` | Learn while loading context |
+| Want to understand patterns | `/session-start-teach` | Learn while loading context |
 
 ## Integration with Other Skills/Bundles
 


### PR DESCRIPTION
Replace flag-based mode switching with separate commands for better reliability.

Changes:
- Split /session-start into two commands:
  * /session-start: Standard mode (brief, efficient, ~3200 tokens)
  * /session-start-teach: Teacher mode (educational, verbose, ~4200 tokens)
- Removed MODE DETECTION section (no longer needed)
- Updated plugin.json to register new command
- Updated SKILL.md documentation with new command structure
- Updated README.md with comprehensive examples of both modes

Benefits:
- Eliminates flag detection issues completely
- Each command has one clear purpose (no conditional logic)
- Token savings: -1300 tokens per invocation (no unused sections)
- Improved reliability and maintainability
- Better user experience (explicit command names)

Token costs:
- /session-start: ~3200-3500 tokens (was ~4500)
- /session-start-teach: ~4200-4500 tokens (was ~5500)
- /session-end: ~2000-2500 tokens (unchanged)